### PR TITLE
feat: add custom retry dialog for server errors in side panel

### DIFF
--- a/MagicPocket-chrome-extension/src/content/textHighlight.js
+++ b/MagicPocket-chrome-extension/src/content/textHighlight.js
@@ -449,7 +449,7 @@ const highlightRange = (range, highlightInfo) => {
             tempDiv.parentNode.removeChild(tempDiv);
         }
     } catch (error) {
-        console.warn('Failed to highlight range:', error);
+        window.Logger.log(window.LogCategory.SYSTEM, 'highlight_range_failed', { error: error.message, highlightInfo: highlightInfo, url: window.location.href });
         try {
             const fragment = range.extractContents();
             const span = createHighlightSpan(highlightInfo);

--- a/MagicPocket-chrome-extension/src/sidePanel/sidePanel.css
+++ b/MagicPocket-chrome-extension/src/sidePanel/sidePanel.css
@@ -364,3 +364,63 @@ body.resizing #recordsScrollArea,
 body.resizing #networkVisualizationContainer {
     transition: none;
 }
+
+/* Dialog styles */
+.mp-custom-dialog {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+}
+
+.mp-dialog-content {
+    background-color: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    max-width: 90%;
+    width: 300px;
+}
+
+.mp-dialog-content p {
+    margin: 0 0 20px 0;
+    text-align: center;
+    color: #4a5568;
+    font-size: 14px;
+}
+
+.mp-dialog-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+}
+
+.mp-dialog-buttons button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.2s;
+}
+
+.mp-dialog-buttons .mp-cancel-btn {
+    background-color: #EDF2F7;
+    color: #4A5568;
+}
+
+.mp-dialog-buttons .mp-retry-btn {
+    background-color: #4299E1;
+    color: white;
+}
+
+.mp-dialog-buttons button:hover {
+    transform: translateY(-1px);
+    filter: brightness(0.95);
+}


### PR DESCRIPTION
- Implemented a new dialog that prompts users to retry or cancel when a server error (422) occurs during group requests.
- Enhanced user experience by allowing users to decide whether to retry or cancel the operation.